### PR TITLE
Upgrade dependencies for Crystal v0.30.0

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -1,16 +1,16 @@
 version: 1.0
 shards:
   callback:
-    github: mosop/callback
-    version: 0.6.3
+    github: bcardiff/callback
+    commit: 8dc1c3b0f461332fceb4db5c276c7bfcfbe38481
 
   cli:
-    github: amberframework/cli
-    version: 0.7.0
+    github: bcardiff/cli
+    commit: 785086069823569f67302465d17de4b1286536a0
 
   optarg:
-    github: mosop/optarg
-    version: 0.5.8
+    github: bcardiff/optarg
+    commit: c4ed4d4b84521c6bf5121af0ee277b591b9ce30d
 
   string_inflection:
     github: mosop/string_inflection

--- a/shard.yml
+++ b/shard.yml
@@ -10,8 +10,10 @@ targets:
 
 dependencies:
   cli:
-    github: mosop/cli
-    version: ~> 0.7.0
+    # github: mosop/cli
+    # version: ~> 0.7.0
+    github: bcardiff/cli
+    branch: bcardiff/use-fork
 
 crystal: 0.27
 


### PR DESCRIPTION
Once the following PR are merged and released the overrided dependencies should be updated.

* https://github.com/mosop/callback/pull/2
* https://github.com/mosop/optarg/pull/7
* https://github.com/mosop/cli/pull/19

Disclaimer: Do not depend on my forks :-)