### PR TITLE
Update to Crystal 0.33.0

### DIFF
--- a/src/cry/code_runner.cr
+++ b/src/cry/code_runner.cr
@@ -1,6 +1,6 @@
 module Cry
   class CodeRunner
-    private getter filename_seed : Int64 = Time.now.to_unix_ms
+    private getter filename_seed : Int64 = Time.local.to_unix_ms
     private getter code : String
     private getter editor : String
     private getter back : Int32


### PR DESCRIPTION
`Time.now` was deprecated in 0.28.0 and will be removed in 0.33.0