### PR TITLE
Update crystal version constraint to allow through 1.0

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -1,18 +1,2 @@
-version: 1.0
-shards:
-  callback:
-    github: mosop/callback
-    version: 0.6.3
-
-  cli:
-    github: amberframework/cli
-    version: 0.7.0
-
-  optarg:
-    github: mosop/optarg
-    version: 0.5.8
-
-  string_inflection:
-    github: mosop/string_inflection
-    version: 0.2.1
-
+version: 2.0
+shards: {}

--- a/shard.yml
+++ b/shard.yml
@@ -9,6 +9,6 @@ targets:
   cry:
     main: src/cry.cr
 
-crystal: 0.33.0
+crystal: ">= 0.33.0, < 2.0.0"
 
 license: MIT


### PR DESCRIPTION
Updates the version constraint to allow through 1.0 and beyond.